### PR TITLE
Updated Chirp.Web TargetFramework

### DIFF
--- a/src/Chirp.Web/Chirp.Web.csproj
+++ b/src/Chirp.Web/Chirp.Web.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>net$(NETCoreAppMaximumVersion)</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
         <RootNamespace>Chirp.Web</RootNamespace>


### PR DESCRIPTION
## What
- Updated <TargetFramework> field in Chirp.Web.csproj to use .NET 9 rather than .NET 10

## Why
- To complete issue #83

## How
- Only one line of code had to be changed: see section ' **What** '

## Checklist
- [x] Builds locally
- [x] Follows conventions
- [x] No direct changes to main
