### PR TITLE
Cheep.Repository and Cheep.Repository.Tests hotfix

### DIFF
--- a/src/Chirp.Infrastructure/Chirp.Repositories/Chirp.AuthorRepository/AuthorRepository.cs
+++ b/src/Chirp.Infrastructure/Chirp.Repositories/Chirp.AuthorRepository/AuthorRepository.cs
@@ -3,7 +3,7 @@ using Chirp.Core.DTOs;
 using Chirp.Database;
 using Microsoft.EntityFrameworkCore;
 
-namespace Chirp.Repositories.AuthorRepository;
+namespace Chirp.Repositories;
 
 public class AuthorRepository(ChirpDBContext dbContext) : IAuthorRepository
 {

--- a/src/Chirp.Infrastructure/Chirp.Repositories/Chirp.AuthorRepository/Chirp.AuthorRepository.csproj
+++ b/src/Chirp.Infrastructure/Chirp.Repositories/Chirp.AuthorRepository/Chirp.AuthorRepository.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\..\Chirp.Core\Chirp.Core.csproj" />
-    <ProjectReference Include="..\..\..\Chirp.Infrastructure\Chirp.Database\Chirp.Database.csproj" />
+    <ProjectReference Include="..\..\Chirp.Database\Chirp.Database.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Chirp.Infrastructure/Chirp.Repositories/Chirp.AuthorRepository/IAuthorRepository.cs
+++ b/src/Chirp.Infrastructure/Chirp.Repositories/Chirp.AuthorRepository/IAuthorRepository.cs
@@ -1,7 +1,7 @@
 ﻿using Chirp.Core;
 using Chirp.Core.DTOs;
 
-namespace Chirp.Repositories.AuthorRepository;
+namespace Chirp.Repositories;
 
 public interface IAuthorRepository
 {

--- a/src/Chirp.Infrastructure/Chirp.Repositories/Chirp.CheepRepository/CheepRepository.cs
+++ b/src/Chirp.Infrastructure/Chirp.Repositories/Chirp.CheepRepository/CheepRepository.cs
@@ -4,7 +4,7 @@ using Chirp.Core.Helpers;
 using Chirp.Database;
 using Microsoft.EntityFrameworkCore;
 
-namespace Chirp.Repositories.CheepRepository;
+namespace Chirp.Repositories;
 
 public class CheepRepository(ChirpDBContext dbContext) : ICheepRepository //Queries
 {

--- a/src/Chirp.Infrastructure/Chirp.Repositories/Chirp.CheepRepository/Chirp.CheepRepository.csproj
+++ b/src/Chirp.Infrastructure/Chirp.Repositories/Chirp.CheepRepository/Chirp.CheepRepository.csproj
@@ -12,7 +12,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\..\Chirp.Core\Chirp.Core.csproj" />
-    <ProjectReference Include="..\..\..\Chirp.Infrastructure\Chirp.Database\Chirp.Database.csproj" />
+    <ProjectReference Include="..\..\Chirp.Database\Chirp.Database.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Chirp.Infrastructure/Chirp.Repositories/Chirp.CheepRepository/ICheepRepository.cs
+++ b/src/Chirp.Infrastructure/Chirp.Repositories/Chirp.CheepRepository/ICheepRepository.cs
@@ -1,7 +1,7 @@
 ﻿using Chirp.Core;
 using Chirp.Core.DTOs;
 
-namespace Chirp.Repositories.CheepRepository;
+namespace Chirp.Repositories;
 
 public interface ICheepRepository
 {

--- a/src/Chirp.Infrastructure/Chirp.Repositories/Chirp.FollowerRepository/Chirp.FollowerRepository.csproj
+++ b/src/Chirp.Infrastructure/Chirp.Repositories/Chirp.FollowerRepository/Chirp.FollowerRepository.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\..\Chirp.Core\Chirp.Core.csproj" />
-    <ProjectReference Include="..\..\..\Chirp.Infrastructure\Chirp.Database\Chirp.Database.csproj" />
+    <ProjectReference Include="..\..\Chirp.Database\Chirp.Database.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Chirp.Infrastructure/Chirp.Repositories/Chirp.FollowerRepository/FollowerRepository.cs
+++ b/src/Chirp.Infrastructure/Chirp.Repositories/Chirp.FollowerRepository/FollowerRepository.cs
@@ -3,7 +3,7 @@ using Chirp.Core.DTOs;
 using Chirp.Database;
 using Microsoft.EntityFrameworkCore;
 
-namespace Chirp.Repositories.FollowerRepository;
+namespace Chirp.Repositories;
 
 public class FollowerRepository(ChirpDBContext dbContext) : IFollowerRepository
 {

--- a/src/Chirp.Infrastructure/Chirp.Repositories/Chirp.FollowerRepository/IFollowerRepository.cs
+++ b/src/Chirp.Infrastructure/Chirp.Repositories/Chirp.FollowerRepository/IFollowerRepository.cs
@@ -1,7 +1,7 @@
 ﻿using Chirp.Core;
 using Chirp.Core.DTOs;
 
-namespace Chirp.Repositories.FollowerRepository;
+namespace Chirp.Repositories;
 
 public interface IFollowerRepository
 {

--- a/src/Chirp.Infrastructure/Chirp.Services/Builder.cs
+++ b/src/Chirp.Infrastructure/Chirp.Services/Builder.cs
@@ -1,8 +1,6 @@
 ﻿using Chirp.Core;
 using Chirp.Database;
-using Chirp.Repositories.AuthorRepository;
-using Chirp.Repositories.CheepRepository;
-using Chirp.Repositories.FollowerRepository;
+using Chirp.Repositories;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;

--- a/src/Chirp.Web/Pages/AboutMe.cshtml.cs
+++ b/src/Chirp.Web/Pages/AboutMe.cshtml.cs
@@ -1,8 +1,6 @@
 using Chirp.Core.DTOs;
 using Chirp.Database;
-using Chirp.Repositories.AuthorRepository;
-using Chirp.Repositories.CheepRepository;
-using Chirp.Repositories.FollowerRepository;
+using Chirp.Repositories;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;

--- a/src/Chirp.Web/Pages/Public.cshtml.cs
+++ b/src/Chirp.Web/Pages/Public.cshtml.cs
@@ -1,7 +1,5 @@
 ﻿using Chirp.Database;
-using Chirp.Repositories.AuthorRepository;
-using Chirp.Repositories.CheepRepository;
-using Chirp.Repositories.FollowerRepository;
+using Chirp.Repositories;
 using Chirp.Web.Pages.Shared;
 using Microsoft.AspNetCore.Mvc;
 

--- a/src/Chirp.Web/Pages/Shared/TimelineModel.cs
+++ b/src/Chirp.Web/Pages/Shared/TimelineModel.cs
@@ -1,12 +1,8 @@
 using System.ComponentModel.DataAnnotations;
 using Chirp.Core.DTOs;
 using Chirp.Database;
-using Chirp.Repositories.AuthorRepository;
-using Chirp.Repositories.CheepRepository;
-using Chirp.Repositories.FollowerRepository;
+using Chirp.Repositories;
 using Chirp.Services;
-using Microsoft.AspNetCore.Authentication;
-using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 

--- a/src/Chirp.Web/Pages/UserTimeline.cshtml.cs
+++ b/src/Chirp.Web/Pages/UserTimeline.cshtml.cs
@@ -1,7 +1,5 @@
 ﻿using Chirp.Database;
-using Chirp.Repositories.AuthorRepository;
-using Chirp.Repositories.CheepRepository;
-using Chirp.Repositories.FollowerRepository;
+using Chirp.Repositories;
 using Chirp.Web.Pages.Shared;
 using Microsoft.AspNetCore.Mvc;
 

--- a/test/Chirp.Infrastructure.Tests/Chirp.Repositories.Tests/CheepRepositoryUnitTests.cs
+++ b/test/Chirp.Infrastructure.Tests/Chirp.Repositories.Tests/CheepRepositoryUnitTests.cs
@@ -1,11 +1,8 @@
 ﻿using Chirp.Core;
 using Chirp.Database;
-using Chirp.Repositories.AuthorRepository;
-using Chirp.Repositories.CheepRepository;
 using Microsoft.EntityFrameworkCore;
-using Xunit;
 
-namespace Chirp.Web.Tests;
+namespace Chirp.Repositories.Tests;
 
 public class CheepRepositoryUnitTests
 {
@@ -54,6 +51,8 @@ public class CheepRepositoryUnitTests
         Assert.NotEmpty(results); //Testing that results isnt emmpty
         Assert.All(results, cheep => Assert.Equal("Eddie", cheep.AuthorName));
         //Testing that GetCheepsFromAuthorAsync works with results only having cheeps from specific author
+
+        dbContext.Database.EnsureDeleted();
     }
 
     [Fact]
@@ -106,6 +105,8 @@ public class CheepRepositoryUnitTests
         //Assert
         Assert.Equal(32, page1.Count); //Should return true if page1 has 32 cheeps
         Assert.Equal(5, page2.Count); //Should return true if page2 has 5 cheeps.
+
+        dbContext.Database.EnsureDeleted();
     }
 
     [Fact]
@@ -165,6 +166,8 @@ public class CheepRepositoryUnitTests
 
         //Assert
         Assert.Equal(14, results);
+
+        dbContext.Database.EnsureDeleted();
     }
 
     [Fact]
@@ -224,6 +227,8 @@ public class CheepRepositoryUnitTests
         Assert.Equal(11, vinnieresults);
         Assert.Equal(3, oliresults);
         //Checking that we receive the correct amount of cheeps from specific authors
+
+        dbContext.Database.EnsureDeleted();
     }
 
     [Fact]
@@ -252,6 +257,8 @@ public class CheepRepositoryUnitTests
         //and that we can get the author from that name.
         Assert.NotNull(results);
         Assert.Equal("Eddie", results.UserName);
+
+        dbContext.Database.EnsureDeleted();
     }
 
     [Fact]
@@ -282,6 +289,8 @@ public class CheepRepositoryUnitTests
         //Testing if it is true that the result(Jack) would not belong to any author
         //and therefore it should return null.
         Assert.Null(results);
+
+        dbContext.Database.EnsureDeleted();
     }
 
     [Fact]
@@ -310,6 +319,8 @@ public class CheepRepositoryUnitTests
         //and that we can get the author from that email.
         Assert.NotNull(results);
         Assert.Equal(author.Email, results.Email);
+
+        dbContext.Database.EnsureDeleted();
     }
 
     [Fact]
@@ -339,5 +350,7 @@ public class CheepRepositoryUnitTests
         //Testing if it is true that the result(jack@itu.dk) would not belong to any author
         //and therefore it should return null.
         Assert.Null(results);
+
+        dbContext.Database.EnsureDeleted();
     }
 }

--- a/test/Chirp.Infrastructure.Tests/Chirp.Repositories.Tests/Chirp.Repositories.Tests.csproj
+++ b/test/Chirp.Infrastructure.Tests/Chirp.Repositories.Tests/Chirp.Repositories.Tests.csproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.10"/>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />


### PR DESCRIPTION
## What
- Forgor to add SQLite package to Cheep.Repository.Tests, that's been fixed
- Renamed CheepRepositoryUnitTests-class namespace from Chirp.Web.Tests to Chirp.Repositories.Tests: this screwed with the fact that the repos' namespaces were 'Chirp.Repositories.AuthorRepository' etc. so, finally:
- Changed AuthorRepository (+interface), CheepRepository (+interface) and FollowerRepository (+interface) namespaces to a simple and uniform 'Chirp.Repositories': this meant I had to change a lot of usings in a lot of files, but alas, the tests finally work again

Sorry for the rant. TL;DR namespaces go brr, I fix

## Why
- To fix tests and architecture

## Checklist
- [x] Builds locally
- [x] Follows conventions
- [x] No direct changes to main
